### PR TITLE
Geänderte DLRG-Assets können schneller veröffentlicht werden

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,7 +1,8 @@
-# only build and deploy when new tags are pushed
 on:
   release:
     types: [ published ]
+  push: # additional check later to run only when message contains '[CI]'
+    branches: [ "main" ]
   workflow_dispatch:
 
 name: build and deploy
@@ -11,6 +12,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && contains(github.event.head_commit.message, '[CI]')) 
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo

--- a/.github/workflows/download_assets.yml
+++ b/.github/workflows/download_assets.yml
@@ -30,23 +30,8 @@ jobs:
     - name: download assets
       run: npx tsx scripts/download_assets.ts
 
-    - name: check if there are uncommitted changes
-      shell: bash
-      id: changes
-      run: |
-        clean=$(git status --porcelain)
-        if [ -z "$clean" ]; then
-          echo "No changes found, skipping next step";
-          result="clean";
-        else
-          echo "New/changed assets found, creating PR";
-          result="dirty";
-        fi
-        echo "status=${result}" >> $GITHUB_OUTPUT
-
     - name: Create/Update Pull Request
       uses: peter-evans/create-pull-request@v6
-      if: ${{ steps.changes.outputs.status  == 'dirty' }}
       with:
         add-paths: public/dlrg-assets
         branch: update/assets
@@ -57,5 +42,4 @@ jobs:
         commit-message: "update assets"
         author: tristankechlo <66692834+tristankechlo@users.noreply.github.com>
         committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-        labels: |
-          changed assets
+        labels: changed assets

--- a/README.md
+++ b/README.md
@@ -10,4 +10,8 @@
 
 > [!IMPORTANT]
 > Jegliche Inhalte, die zum Anzeigen der Qualifikationen genutzt werden, stammen aus der öffentlichen API der DLRG [api.dlrg.net](https://api.dlrg.net/?urls.primaryName=Digitale%20Pr%C3%BCfungsordnung).  
-> Bei fehlenden Informationen oder inhaltlichen Fehlern ist es wahrscheinlich, dass die Daten dort nicht korrekt eingepflegt worden sind.    
+> Bei fehlenden Informationen oder inhaltlichen Fehlern ist es wahrscheinlich, dass die Daten dort nicht korrekt eingepflegt worden sind.
+
+> [!IMPORTANT]
+> Die API kann auch Inhalte (Qualifikationen/Prüfungsinhalte,...) enthalten, die noch nicht in einer Prüfungsordnung veröffentlicht wurden.  
+> Bitte prüfe immer die aktuelle Prüfungsordnung für eine genaue Aussage welche Vorraussetzungen zum Erreichen einer Qualifikation benötigt werden.

--- a/src/layout/ProjectInfo.tsx
+++ b/src/layout/ProjectInfo.tsx
@@ -61,6 +61,10 @@ export default function ProjectInfoModal() {
                             </Flex>
                             <Text mt='sm'>Bei fehlenden Informationen oder inhaltlichen Fehlern ist es wahrscheinlich, dass die Daten dort nicht korrekt eingepflegt worden sind.</Text>
                         </Alert>
+                        <Alert mt='md' variant='light' icon={<IconInfoCircle />} classNames={{ icon: classes.alertIcon }}>
+                            <Text>Die API kann auch Inhalte (Qualifikationen/Prüfungsinhalte,...) enthalten, die noch nicht in einer Prüfungsordnung veröffentlicht wurden.</Text>
+                            <Text mt='sm'>Bitte prüfe immer die aktuelle Prüfungsordnung für eine genaue Aussage welche Vorraussetzungen zum Erreichen einer Qualifikation benötigt werden.</Text>
+                        </Alert>
                         <Checkbox mt='md' checked={checked} onChange={(event) => setChecked(event.currentTarget.checked)} label="Nicht erneut anzeigen" />
                         <Button fullWidth mt='md' onClick={closeModal}>Schließen</Button>
                     </Modal.Body>


### PR DESCRIPTION
Alle commits auf main die den Text `[CI]` enthalten, starten den build/deploy workflow.  
Zu dem Zweck gibt es eine neue Info, welche erklärt das die App Daten enthält welche noch nicht in einer PO veröffentlicht wurden.